### PR TITLE
Override to_partial_path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem "hiredis"
 gem "stimulus_reflex", github: "hopsoft/stimulus_reflex", branch: "master"
 gem "cable_ready", "~> 4.3"
 
-gem "futurism"
+gem "futurism", github: "julianrubisch/futurism", branch: "master"
 gem "faker"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,16 @@ GIT
       rack
       rails (>= 5.2)
 
+GIT
+  remote: https://github.com/julianrubisch/futurism.git
+  revision: 5dacd1ca56424a583b45b8e9af994d401df7f5fc
+  branch: master
+  specs:
+    futurism (0.1.1)
+      cable_ready (>= 4)
+      rack (~> 2.0)
+      rails (>= 6, >= 5.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -80,10 +90,6 @@ GEM
     faker (2.13.0)
       i18n (>= 1.6, < 2)
     ffi (1.13.1)
-    futurism (0.1.1)
-      cable_ready (>= 4)
-      rack (~> 2.0)
-      rails (>= 6, >= 5.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hiredis (0.6.3)
@@ -207,7 +213,7 @@ DEPENDENCIES
   byebug
   cable_ready (~> 4.3)
   faker
-  futurism
+  futurism!
   hiredis
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,2 +1,5 @@
 class Post < ApplicationRecord
+  def to_partial_path
+    "home/post"
+  end
 end


### PR DESCRIPTION
So the problem is that the default implementation of `to_partial_path` points to `app/views/{resources}/_{resource}.html.erb`

you can override that though!

actually a good sanity check, will add it to the readme